### PR TITLE
Migrate to tide 0.15, opentelemetry 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-tide"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Christoph Grabo <asaaki@mannaz.cc>"]
 edition = "2018"
 readme = "README.md"
@@ -12,20 +12,19 @@ categories = [
   "development-tools::profiling",
   "asynchronous",
   "web-programming",
-  "network-programming"
+  "network-programming",
 ]
 keywords = ["tide", "opentelemetry", "jaeger", "tracing", "instrumentation"]
 license = "MIT OR Apache-2.0"
 exclude = [".assets/*", ".github/*"]
 
 [dependencies]
-http-types = "2.4"
-kv-log-macro = "1.0"
-opentelemetry = "0.7"
-tide = "0.13"
+opentelemetry = "0.10"
+opentelemetry-semantic-conventions = "0.2"
+tide = "0.15"
 url = "2.1"
 
 [dev-dependencies]
-async-std = {version =  "1.6", features = ["attributes"]}
-opentelemetry-jaeger = "0.6"
-thrift = "0.13"
+async-std = { version = "1.7", features = ["attributes"] }
+opentelemetry = { version = "0.10", features = ["async-std"] }
+opentelemetry-jaeger = { version = "0.9", features = ["async-std"] }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -2,7 +2,7 @@ use opentelemetry_semantic_conventions::resource;
 use opentelemetry_tide::OpenTelemetryTracingMiddleware;
 use tide::Request;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[async_std::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ impl<T: Tracer + Send + Sync, State: Clone + Send + Sync + 'static> Middleware<S
     for OpenTelemetryTracingMiddleware<T>
 {
     async fn handle(&self, req: Request<State>, next: Next<'_, State>) -> Result {
-        let method = req.method().clone();
+        let method = req.method();
         let url = req.url().clone();
 
         let mut attributes = vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,14 +98,11 @@ impl<T: Tracer + Send + Sync, State: Clone + Send + Sync + 'static> Middleware<S
         let method = req.method();
         let url = req.url().clone();
 
-        let mut attributes = vec![
-            trace::HTTP_METHOD.string(method.to_string()),
-            trace::HTTP_SCHEME.string(url.scheme().to_owned()),
-            trace::HTTP_URL.string(url.to_string()),
-            trace::HTTP_TARGET.string(http_target(&url)),
-        ];
-
-        attributes.reserve(6);
+        let mut attributes = Vec::with_capacity(10); // 4 required and 6 optional values
+        attributes.push(trace::HTTP_METHOD.string(method.to_string()));
+        attributes.push(trace::HTTP_SCHEME.string(url.scheme().to_owned()));
+        attributes.push(trace::HTTP_URL.string(url.to_string()));
+        attributes.push(trace::HTTP_TARGET.string(http_target(&url)));
 
         if let Some(version) = req.version() {
             attributes.push(trace::HTTP_FLAVOR.string(http_version_str(version)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,11 +172,11 @@ fn http_version_str(version: Version) -> &'static str {
 fn http_target(url: &Url) -> String {
     let mut target = String::from(url.path());
     if let Some(q) = url.query() {
-        target.push_str("?");
+        target.push('?');
         target.push_str(q)
     }
     if let Some(f) = url.fragment() {
-        target.push_str("#");
+        target.push('#');
         target.push_str(f);
     }
     target

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,56 +8,41 @@
 //!
 //! ```toml
 //! [dependencies]
-//! async-std = {version =  "1.6", features = ["attributes"]}
-//! opentelemetry = "0.7"
-//! opentelemetry-jaeger = "0.6"
-//! opentelemetry-tide = "0.3"
-//! thrift = "0.13"
-//! tide = "0.13"
+//! async-std = {version =  "1.7", features = ["attributes"]}
+//! opentelemetry = { version = "0.10", features = ["async-std"] }
+//! opentelemetry-jaeger = { version = "0.9", features = ["async-std"] }
+//! opentelemetry-tide = "0.4"
+//! tide = "0.15"
 //! ```
 //!
 //! ## `server.rs`
 //!
 //! ```rust,no_run
-//! use opentelemetry::{api::KeyValue, global, sdk};
+//! use opentelemetry_semantic_conventions::resource;
 //! use opentelemetry_tide::OpenTelemetryTracingMiddleware;
 //! use tide::Request;
 //!
+//! const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+//!
 //! #[async_std::main]
-//! async fn main() -> thrift::Result<()> {
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     tide::log::start();
-//!     // Make sure to initialize the tracer
-//!     init_tracer()?;
+//!
+//!     let tags = [resource::SERVICE_VERSION.string(VERSION)];
+//!
+//!     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
+//!         .with_service_name("example-server")
+//!         .with_tags(tags.iter().map(ToOwned::to_owned))
+//!         .install()
+//!         .expect("pipeline install failure");
 //!
 //!     let mut app = tide::new();
-//!     // Here we add the middleware
-//!     app.with(OpenTelemetryTracingMiddleware::new());
+//!     app.with(OpenTelemetryTracingMiddleware::new(tracer));
 //!     app.at("/").get(|req: Request<()>| async move {
 //!         eprintln!("req.version = {:?}", req.version());
 //!         Ok("Hello, OpenTelemetry!")
 //!     });
 //!     app.listen("127.0.0.1:3000").await?;
-//!
-//!     Ok(())
-//! }
-//!
-//! fn init_tracer() -> thrift::Result<()> {
-//!     let exporter = opentelemetry_jaeger::Exporter::builder()
-//!         .with_agent_endpoint("127.0.0.1:6831".parse().expect("not a valid endpoint"))
-//!         .with_process(opentelemetry_jaeger::Process {
-//!             service_name: "example-server".into(),
-//!             tags: vec![KeyValue::new("exporter", "jaeger")],
-//!         })
-//!         .init()?;
-//!
-//!     let provider = sdk::Provider::builder()
-//!         .with_simple_exporter(exporter)
-//!         .with_config(sdk::Config {
-//!             default_sampler: Box::new(sdk::Sampler::AlwaysOn),
-//!             ..Default::default()
-//!         })
-//!         .build();
-//!     global::set_provider(provider);
 //!
 //!     Ok(())
 //! }
@@ -68,140 +53,102 @@
 #![deny(missing_docs)]
 #![deny(unused_imports)]
 #![deny(missing_debug_implementations)]
+#![warn(clippy::expect_used)]
+#![deny(clippy::unwrap_used)]
+#![deny(unused_results)]
 #![doc(test(attr(allow(unused_variables), deny(warnings))))]
-#![allow(clippy::all)]
 
-use {
-    http_types::{
-        headers::{HeaderName, HeaderValue},
-        Version,
-    },
-    kv_log_macro as log,
-    opentelemetry::{
-        api::{
-            trace::b3_propagator::B3Encoding, B3Propagator, Context, HttpTextCompositePropagator, HttpTextFormat,
-            KeyValue, SpanKind, StatusCode, TraceContextPropagator, Tracer, Value,
-        },
-        global,
-    },
-    tide::{Middleware, Next, Request, Result},
-    url::Url,
+use std::convert::TryFrom;
+
+use opentelemetry::{
+    trace::{FutureExt, SpanKind, StatusCode, TraceContextExt, Tracer},
+    Context,
 };
-
-static HTTP_METHOD_ATTRIBUTE: &str = "http.method";
-static HTTP_URL_ATTRIBUTE: &str = "http.url";
-static HTTP_TARGET_ATTRIBUTE: &str = "http.target";
-static HTTP_SCHEME_ATTRIBUTE: &str = "http.scheme";
-static HTTP_STATUS_CODE_ATTRIBUTE: &str = "http.status_code";
-static HTTP_STATUS_TEXT_ATTRIBUTE: &str = "http.status_text";
-static HTTP_FLAVOR_ATTRIBUTE: &str = "http.flavor";
-// TODO: parse UA header
-// static HTTP_USER_AGENT_ATTRIBUTE: &str = "http.user_agent";
-
-static HTTP_HOST_ATTRIBUTE: &str = "http.host";
-static HTTP_SERVER_NAME_ATTRIBUTE: &str = "http.server_name";
-// needs access to the framework's router:
-// static HTTP_ROUTE_ATTRIBUTE: &str = "http.route";
-static HTTP_CLIENT_IP_ATTRIBUTE: &str = "http.client_ip";
-static NET_PEER_IP_ATTRIBUTE: &str = "net.peer.ip";
-static NET_HOST_PORT_ATTRIBUTE: &str = "net.host.port";
-static UNKNOWN: &str = "unknown";
-static EMPTY: &str = "";
+use opentelemetry_semantic_conventions::trace;
+use tide::{http::Version, Middleware, Next, Request, Result};
+use url::Url;
 
 /// The middleware struct to be used in tide
 #[derive(Default, Debug)]
-pub struct OpenTelemetryTracingMiddleware {
-    _priv: (),
+pub struct OpenTelemetryTracingMiddleware<T: Tracer> {
+    tracer: T,
 }
 
-impl OpenTelemetryTracingMiddleware {
+impl<T: Tracer> OpenTelemetryTracingMiddleware<T> {
     /// Instantiate the middleware
     ///
     /// # Examples
     ///
     /// ```rust,no_run
-    /// // make sure to initialize the tracer first
-    ///
     /// let mut app = tide::new();
-    /// app.with(opentelemetry_tide::OpenTelemetryTracingMiddleware::new());
+    /// let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline().install().unwrap();
+    /// app.with(opentelemetry_tide::OpenTelemetryTracingMiddleware::new(tracer));
     /// app.at("/").get(|_| async { Ok("Traced!") });
     /// ```
-    pub fn new() -> Self {
-        Self { _priv: () }
+    pub fn new(tracer: T) -> Self {
+        Self { tracer }
     }
 }
 
 #[tide::utils::async_trait]
-impl<State: Clone + Send + Sync + 'static> Middleware<State> for OpenTelemetryTracingMiddleware {
+impl<T: Tracer + Send + Sync, State: Clone + Send + Sync + 'static> Middleware<State>
+    for OpenTelemetryTracingMiddleware<T>
+{
     async fn handle(&self, req: Request<State>, next: Next<'_, State>) -> Result {
-        let mut req_headers = std::collections::HashMap::new();
-        for (k, v) in req.iter() {
-            req_headers.insert(k.to_string(), v.last().to_string());
+        let method = req.method().clone();
+        let url = req.url().clone();
+
+        let mut attributes = vec![
+            trace::HTTP_METHOD.string(method.to_string()),
+            trace::HTTP_SCHEME.string(url.scheme().to_owned()),
+            trace::HTTP_URL.string(url.to_string()),
+            trace::HTTP_TARGET.string(http_target(&url)),
+        ];
+
+        attributes.reserve(6);
+
+        if let Some(version) = req.version() {
+            attributes.push(trace::HTTP_FLAVOR.string(http_version_str(version)));
         }
 
-        let b3_propagator = B3Propagator::with_encoding(B3Encoding::SingleAndMultiHeader);
-        let trace_context_propagator = TraceContextPropagator::new();
-        let composite_propagator =
-            HttpTextCompositePropagator::new(vec![Box::new(b3_propagator), Box::new(trace_context_propagator)]);
-        let _parent = composite_propagator
-            .extract_with_context(&Context::current(), &req_headers)
-            .attach();
-        let tracer = global::tracer("opentelemetry-tide");
-        let span_name = format!("{} {}", req.method(), req.url());
-        let mut builder = tracer.span_builder(&span_name);
-        builder.span_kind = Some(SpanKind::Server);
+        if let Some(host) = url.host_str() {
+            attributes.push(trace::HTTP_HOST.string(host.to_owned()));
+        }
 
-        let url = req.url();
-        let attributes = vec![
-            KeyValue::new(HTTP_METHOD_ATTRIBUTE, req.method().to_string()),
-            KeyValue::new(HTTP_FLAVOR_ATTRIBUTE, http_version_str(req.version())),
-            KeyValue::new(HTTP_SCHEME_ATTRIBUTE, url.scheme()),
-            KeyValue::new(HTTP_URL_ATTRIBUTE, url.as_str()),
-            KeyValue::new(HTTP_HOST_ATTRIBUTE, url.host_str().unwrap_or(UNKNOWN)),
-            KeyValue::new(HTTP_TARGET_ATTRIBUTE, http_target(url)),
-            KeyValue::new(HTTP_SERVER_NAME_ATTRIBUTE, url.domain().unwrap_or(UNKNOWN)),
-            KeyValue::new(
-                NET_HOST_PORT_ATTRIBUTE,
-                Value::U64(url.port_or_known_default().unwrap_or(0u16) as u64),
-            ),
-            KeyValue::new(HTTP_CLIENT_IP_ATTRIBUTE, net_addr_ip(req.peer_addr())),
-            KeyValue::new(NET_PEER_IP_ATTRIBUTE, net_addr_ip(req.remote())),
-        ];
-        builder.attributes = Some(attributes);
-        let span = tracer.build(builder);
-        let _guard = tracer.mark_span_as_active(span);
+        if let Some(domain) = url.domain() {
+            attributes.push(trace::HTTP_SERVER_NAME.string(domain.to_owned()));
+        }
+
+        if let Some(port) = url.port_or_known_default() {
+            attributes.push(trace::NET_HOST_PORT.i64(port.into()));
+        }
+
+        if let Some(addr) = req.remote() {
+            attributes.push(trace::NET_PEER_IP.string(net_addr_ip(addr)));
+        }
+
+        if let Some(addr) = req.peer_addr() {
+            attributes.push(trace::HTTP_CLIENT_IP.string(net_addr_ip(addr)));
+        }
+
+        let span = self
+            .tracer
+            .span_builder(&format!("{} {}", method, url))
+            .with_kind(SpanKind::Server)
+            .with_attributes(attributes)
+            .start(&self.tracer);
+        let cx = Context::current_with_span(span);
 
         // call next in the chain
-        let mut res = next.run(req).await;
+        let res = next.run(req).with_context(cx.clone()).await;
 
-        tracer.get_active_span(|span| {
-            span.set_attribute(KeyValue::new(
-                HTTP_STATUS_CODE_ATTRIBUTE,
-                Value::U64(res.status() as u16 as u64),
-            ));
-            span.set_attribute(KeyValue::new(
-                HTTP_STATUS_TEXT_ATTRIBUTE,
-                res.status().canonical_reason(),
-            ));
-            span.set_attribute(KeyValue::new("http.body.length", res.len().map_or(0u64, |v| v as u64)));
+        let span = cx.span();
 
-            if let Some(ct) = res.content_type() {
-                span.set_attribute(KeyValue::new("http.content_type", ct.to_string()));
-            }
+        span.set_status(span_status(res.status()), "".to_string());
+        span.set_attribute(trace::HTTP_STATUS_CODE.i64(u16::from(res.status()).into()));
 
-            span.set_status(span_status(res.status()), EMPTY.to_string());
-        });
-
-        let mut carrier = std::collections::HashMap::new();
-        composite_propagator.inject_context(&Context::current(), &mut carrier);
-        for (k, v) in carrier {
-            let header_name = HeaderName::from_bytes(k.clone().into_bytes());
-            let header_value = HeaderValue::from_bytes(v.clone().into_bytes());
-            if let (Ok(name), Ok(value)) = (header_name, header_value) {
-                res.insert_header(name, value);
-            } else {
-                log::error!("Could not compose header for pair: ({}, {})", k, v);
-            }
+        if let Some(len) = res.len().and_then(|len| i64::try_from(len).ok()) {
+            span.set_attribute(trace::HTTP_RESPONSE_CONTENT_LENGTH.i64(len));
         }
 
         Ok(res)
@@ -209,19 +156,15 @@ impl<State: Clone + Send + Sync + 'static> Middleware<State> for OpenTelemetryTr
 }
 
 #[inline]
-fn http_version_str(version: Option<Version>) -> &'static str {
+fn http_version_str(version: Version) -> &'static str {
     use Version::*;
-    if let Some(v) = version {
-        match v {
-            Http0_9 => "0.9",
-            Http1_0 => "1.0",
-            Http1_1 => "1.1",
-            Http2_0 => "2.0",
-            Http3_0 => "3.0",
-            _ => UNKNOWN,
-        }
-    } else {
-        UNKNOWN
+    match version {
+        Http0_9 => "0.9",
+        Http1_0 => "1.0",
+        Http1_1 => "1.1",
+        Http2_0 => "2.0",
+        Http3_0 => "3.0",
+        _ => "unknown",
     }
 }
 
@@ -240,13 +183,9 @@ fn http_target(url: &Url) -> String {
 }
 
 #[inline]
-fn net_addr_ip(input: Option<&str>) -> String {
-    if let Some(addr) = input {
-        let (ip_string, _port) = addr_to_tuple(addr);
-        ip_string
-    } else {
-        UNKNOWN.to_string()
-    }
+fn net_addr_ip(input: &str) -> String {
+    let (ip_string, _port) = addr_to_tuple(input);
+    ip_string
 }
 
 #[inline]
@@ -260,26 +199,7 @@ fn addr_to_tuple(input: &str) -> (String, u16) {
 #[inline]
 fn span_status(http_status: tide::StatusCode) -> StatusCode {
     match http_status as u16 {
-        100..=399 => StatusCode::OK,
-        401 => StatusCode::Unauthenticated,
-        403 => StatusCode::PermissionDenied,
-        404 => StatusCode::NotFound,
-        429 => StatusCode::ResourceExhausted,
-        #[allow(clippy::match_overlapping_arm)]
-        400..=499 => StatusCode::InvalidArgument,
-        501 => StatusCode::Unimplemented,
-        503 => StatusCode::Unavailable,
-        504 => StatusCode::DeadlineExceeded,
-        #[allow(clippy::match_overlapping_arm)]
-        500..=599 => StatusCode::Internal,
-        _ => StatusCode::Unknown,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
+        100..=399 => StatusCode::Ok,
+        _ => StatusCode::Error,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,7 @@ fn socket_str_to_ip(socket: &str) -> Option<IpAddr> {
 fn span_status(http_status: tide::StatusCode) -> StatusCode {
     match http_status as u16 {
         100..=399 => StatusCode::Ok,
-        _ => StatusCode::Error,
+        400..=599 => StatusCode::Error,
+        _ => StatusCode::Unset,
     }
 }


### PR DESCRIPTION
Hi!

First off, thanks for this cool lib. Second, sorry for the huge patch. Jumping from 0.7 to 0.10 was fairly significant which on the upside massively simplifies the API internally in the middleware, and for library users as well as removing a few dependencies but on the downside required fairly significant refactors.

One of the nicer things is now we are able to depend on `opentelemetry-semantic-conventions` to remove a bunch of consts from the lib, and we don't have to worry about setting up transports and things. I _believe_ this PR has feature-parity bar some removed tags but if I've missed something let me know! Because this is quite large, I've added review comments to explain my reasoning below.

Cheers

Alex