### PR TITLE
Add propagation

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -35,10 +35,9 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('**/Cargo.toml', '**/src/lib.rs') }}-${{ matrix.cache_counter }}
+        key: ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ matrix.cache_counter }}-${{ hashFiles('**/Cargo.toml', '**/src/lib.rs') }}-${{ matrix.cache_counter }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('**/Cargo.toml', '**/src/lib.rs') }}-
-          ${{ runner.os }}-${{ matrix.rust }}-cargo-
+          ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ matrix.cache_counter }}-
 
     - name: Run cargo fetch
       uses: actions-rs/cargo@v1

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -17,6 +17,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         rust: [stable, beta]
+        exclude:
+          # it fails to often for no reason
+          - os: macos-latest
+            rust: beta
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -35,7 +35,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ matrix.cache_counter }}-${{ hashFiles('**/Cargo.toml', '**/src/lib.rs') }}-${{ matrix.cache_counter }}
+        key: ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ matrix.cache_counter }}-${{ hashFiles('**/Cargo.toml', '**/src/lib.rs') }}
         restore-keys: |
           ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ matrix.cache_counter }}-
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,8 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # disabled: macos-latest
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, windows-latest, macos-11.0]
         rust: [stable, beta]
 
     steps:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest]
         rust: [stable, beta]
         cache_counter: [1]
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,8 +15,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-11.0]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
         rust: [stable, beta]
+        cache_counter: [1]
 
     steps:
     - uses: actions/checkout@v2
@@ -34,8 +35,9 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('**/Cargo.toml', '**/src/lib.rs') }}
+        key: ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('**/Cargo.toml', '**/src/lib.rs') }}-${{ matrix.cache_counter }}
         restore-keys: |
+          ${{ runner.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('**/Cargo.toml', '**/src/lib.rs') }}-
           ${{ runner.os }}-${{ matrix.rust }}-cargo-
 
     - name: Run cargo fetch

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,12 +15,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # disabled: macos-latest
+        os: [ubuntu-latest, windows-latest]
         rust: [stable, beta]
-        exclude:
-          # it fails to often for no reason
-          - os: macos-latest
-            rust: beta
 
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-tide"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Christoph Grabo <asaaki@mannaz.cc>"]
 edition = "2018"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,9 @@ exclude = [".assets/*", ".github/*"]
 opentelemetry = "0.10"
 opentelemetry-semantic-conventions = "0.2"
 tide = "0.15"
-url = "2.1"
+url = "2.2"
+http-types = "2.8"
+kv-log-macro = "1.0"
 
 [dev-dependencies]
 async-std = { version = "1.7", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ kv-log-macro = "1.0"
 async-std = { version = "1.7", features = ["attributes"] }
 opentelemetry = { version = "0.10", features = ["async-std"] }
 opentelemetry-jaeger = { version = "0.9", features = ["async-std"] }
+surf = "2.1"

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ firefox http://localhost:16686/
 
 ```toml
 [dependencies]
-async-std = {version =  "1.6", features = ["attributes"]}
-opentelemetry = "0.7"
-opentelemetry-jaeger = "0.6"
-opentelemetry-tide = "0.3"
+async-std = { version = "1.7", features = ["attributes"] }
+opentelemetry = { version = "0.10", features = ["async-std"] }
+opentelemetry-jaeger = { version = "0.9", features = ["async-std"] }
+opentelemetry-tide = "0.4"
 thrift = "0.13"
 tide = "0.13"
 ```
@@ -74,45 +74,30 @@ tide = "0.13"
 #### `server.rs`
 
 ```rust
-use opentelemetry::{api::KeyValue, global, sdk};
+use opentelemetry::global as otel_global;
+use opentelemetry::sdk::propagation::TraceContextPropagator;
+use opentelemetry_semantic_conventions::resource;
 use opentelemetry_tide::OpenTelemetryTracingMiddleware;
-use tide::Request;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[async_std::main]
-async fn main() -> thrift::Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tide::log::start();
-    // Make sure to initialize the tracer
-    init_tracer()?;
+    otel_global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let tags = [resource::SERVICE_VERSION.string(VERSION)];
+
+    let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
+        .with_service_name("example-server")
+        .with_tags(tags.iter().map(ToOwned::to_owned))
+        .install()
+        .expect("pipeline install failure");
 
     let mut app = tide::new();
-    // Here we add the middleware
-    app.with(OpenTelemetryTracingMiddleware::new());
-    app.at("/").get(|req: Request<()>| async move {
-        eprintln!("req.version = {:?}", req.version());
-        Ok("Hello, OpenTelemetry!")
-    });
+    app.with(OpenTelemetryTracingMiddleware::new(tracer));
+    app.at("/").get(|_| async move { Ok("Hello, OpenTelemetry!") });
     app.listen("127.0.0.1:3000").await?;
-
-    Ok(())
-}
-
-fn init_tracer() -> thrift::Result<()> {
-    let exporter = opentelemetry_jaeger::Exporter::builder()
-        .with_agent_endpoint("127.0.0.1:6831".parse().expect("not a valid endpoint"))
-        .with_process(opentelemetry_jaeger::Process {
-            service_name: "example-server".into(),
-            tags: vec![KeyValue::new("exporter", "jaeger")],
-        })
-        .init()?;
-
-    let provider = sdk::Provider::builder()
-        .with_simple_exporter(exporter)
-        .with_config(sdk::Config {
-            default_sampler: Box::new(sdk::Sampler::AlwaysOn),
-            ..Default::default()
-        })
-        .build();
-    global::set_provider(provider);
 
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn generate_build_vars(output_path: &Path) {
+    let profile = env::var("PROFILE").unwrap();
+    let mut f = File::create(&output_path.join("build_vars.rs")).expect("Could not create user build_vars.rs file");
+    f.write_all(format!("static PROFILE: &'static str = \"{}\";", profile).as_bytes())
+        .expect("Unable to write user agent");
+}
+
+fn main() {
+    let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR not specified");
+    let out_path = Path::new(&out_dir);
+    generate_build_vars(&out_path);
+}

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 fn generate_build_vars(output_path: &Path) {
     let profile = env::var("PROFILE").unwrap();
     let mut f = File::create(&output_path.join("build_vars.rs")).expect("Could not create user build_vars.rs file");
-    f.write_all(format!("static PROFILE: &'static str = \"{}\";", profile).as_bytes())
+    f.write_all(format!("static PROFILE: &str = \"{}\";", profile).as_bytes())
         .expect("Unable to write user agent");
 }
 

--- a/examples/front-server.rs
+++ b/examples/front-server.rs
@@ -15,7 +15,7 @@
 use http_types::headers::{HeaderName, HeaderValue};
 use opentelemetry::{
     global,
-    trace::{FutureExt, Tracer, TraceContextExt},
+    trace::{FutureExt, TraceContextExt, Tracer},
     Context, KeyValue,
 };
 use opentelemetry_semantic_conventions::resource;
@@ -78,7 +78,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let cx = Context::current_with_value(span);
             client.send(surf_request).with_context(cx).await
         };
-
 
         let body = format!(
             "upstream responded with: \n{}",

--- a/examples/front-server.rs
+++ b/examples/front-server.rs
@@ -1,0 +1,98 @@
+//! Example "frontend" server for testing distributed traces
+//!
+//! Start backend before making any calls to the frontend
+//! ```sh
+//! cargo run --example server
+//! ```
+//!
+//! Basic call
+//! ```sh
+//! curl 'http://127.0.0.1:4000/' -i
+//! ```
+//!
+//! And then check jaeger to see multiple spans across services.
+
+use http_types::headers::{HeaderName, HeaderValue};
+use opentelemetry::{
+    global,
+    trace::{FutureExt, Tracer},
+    Context, KeyValue,
+};
+use opentelemetry_semantic_conventions::resource;
+use opentelemetry_tide::OpenTelemetryTracingMiddleware;
+use std::collections::HashMap;
+use tide::Request;
+
+const SVC_NAME: &str = env!("CARGO_CRATE_NAME");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+include!(concat!(env!("OUT_DIR"), "/build_vars.rs"));
+
+mod shared;
+
+#[async_std::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tide::log::start();
+    shared::init_global_propagator();
+
+    let tags = [
+        resource::SERVICE_VERSION.string(VERSION),
+        resource::SERVICE_INSTANCE_ID.string("frontend-753"),
+        resource::PROCESS_EXECUTABLE_PATH.string(std::env::current_exe().unwrap().display().to_string()),
+        resource::PROCESS_PID.string(std::process::id().to_string()),
+        KeyValue::new("process.executable.profile", PROFILE),
+    ];
+
+    let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
+        .with_service_name(SVC_NAME)
+        .with_tags(tags.iter().map(ToOwned::to_owned))
+        .install()
+        .expect("pipeline install failure");
+
+    let mut app = tide::with_state(surf::client());
+    app.with(OpenTelemetryTracingMiddleware::new(tracer));
+
+    app.at("/").get(|req: Request<surf::Client>| async move {
+        // collect current tracing data, so we can pass it down
+        let cx = Context::current();
+        let mut injector = HashMap::new();
+        global::get_text_map_propagator(|propagator| propagator.inject_context(&cx, &mut injector));
+
+        let client = req.state();
+        let mut surf_request = client.get("http://localhost:3000/").build();
+
+        for (k, v) in injector {
+            let header_name = HeaderName::from_bytes(k.clone().into_bytes());
+            let header_value = HeaderValue::from_bytes(v.clone().into_bytes());
+            if let (Ok(name), Ok(value)) = (header_name, header_value) {
+                surf_request.insert_header(name, value);
+            } else {
+                eprintln!("Could not compose header for pair: ({}, {})", k, v);
+            }
+        }
+
+        let upstream_res = async {
+            let tracer = global::tracer("(child)");
+            let span = tracer.start("surf.client.send");
+            let cx = Context::current_with_value(span);
+            client.send(surf_request).with_context(cx).await
+        };
+
+        // let mut ures = ur.with_context(cx).await?;
+
+        let body = format!(
+            "upstream responded with: \n{}",
+            upstream_res
+                .with_context(cx)
+                .await?
+                .take_body()
+                .into_string()
+                .await
+                .unwrap()
+        );
+
+        Ok(body)
+    });
+    app.listen("127.0.0.1:4000").await?;
+
+    Ok(())
+}

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,27 +1,44 @@
+//! Example server for testing
+//!
+//! Basic call (always creates fresh traces):
+//! ```sh
+//! curl 'http://127.0.0.1:3000/' -i
+//! ```
+//!
+//! Call with parent trace (check request and response headers, trace ID should match):
+//! ```sh
+//! curl 'http://127.0.0.1:3000/' -H 'traceparent: 00-00110022003300440055006600770088-0011223344556677-01' -i
+//! ```
+
 use opentelemetry_semantic_conventions::resource;
 use opentelemetry_tide::OpenTelemetryTracingMiddleware;
-use tide::Request;
 
+mod shared;
+
+const SVC_NAME: &str = env!("CARGO_CRATE_NAME");
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[async_std::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tide::log::start();
+    shared::init_global_propagator();
 
-    let tags = [resource::SERVICE_VERSION.string(VERSION)];
+    let tags = [
+        resource::SERVICE_VERSION.string(VERSION),
+        resource::SERVICE_INSTANCE_ID.string("backend-123"),
+        resource::PROCESS_EXECUTABLE_PATH.string(std::env::current_exe().unwrap().display().to_string()),
+        resource::PROCESS_PID.string(std::process::id().to_string()),
+    ];
 
     let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
-        .with_service_name("example-server")
+        .with_service_name(SVC_NAME)
         .with_tags(tags.iter().map(ToOwned::to_owned))
         .install()
         .expect("pipeline install failure");
 
     let mut app = tide::new();
     app.with(OpenTelemetryTracingMiddleware::new(tracer));
-    app.at("/").get(|req: Request<()>| async move {
-        eprintln!("req.version = {:?}", req.version());
-        Ok("Hello, OpenTelemetry!")
-    });
+    app.at("/").get(|_| async move { Ok("Hello, OpenTelemetry!") });
     app.listen("127.0.0.1:3000").await?;
 
     Ok(())

--- a/examples/shared.rs
+++ b/examples/shared.rs
@@ -1,0 +1,38 @@
+use opentelemetry::global;
+use opentelemetry::sdk::propagation::{
+    B3Encoding, B3Propagator, BaggagePropagator, JaegerPropagator, TextMapCompositePropagator, TraceContextPropagator,
+};
+
+pub fn init_global_propagator() {
+    global::set_text_map_propagator(composite_propagator());
+    // OR you could use a single propagator only:
+    // global::set_text_map_propagator(TraceContextPropagator::new());
+}
+
+fn composite_propagator() -> TextMapCompositePropagator {
+    // the good old zipkin format - probably useful for zipkin environments only
+    let b3_propagator = B3Propagator::with_encoding(B3Encoding::SingleAndMultiHeader);
+
+    // W3C spec: https://w3c.github.io/baggage/ - very flexible KV format, can carry more than just trace context data
+    let baggage_propagator = BaggagePropagator::new();
+
+    // Uber's original format - probably only useful in a closed jaeger only setup
+    let jaeger_propagator = JaegerPropagator::new(); // aka Uber headers
+
+    // Yet another W3C spec: https://www.w3.org/TR/trace-context/ - only for trace context info
+    let trace_context_propagator = TraceContextPropagator::new();
+
+    // NB! last wins (and overwrites!); so re-order based on your actual usage or preferences
+    // or leave out propagators you definitely do no use;
+    // of course, if you send all headers with identical values the order doesn't matter.
+    TextMapCompositePropagator::new(vec![
+        Box::new(jaeger_propagator),
+        Box::new(b3_propagator),
+        Box::new(baggage_propagator),
+        Box::new(trace_context_propagator),
+    ])
+}
+
+// make rust (analyzer) happy
+#[allow(dead_code)]
+fn main() {}


### PR DESCRIPTION
With 0.4.0 the propagation code got lost, but as far as I remember it was also not always working properly anyway.
This PR re-adds the logic again and relies on `global` to retrieve the propagator(s) set up by the library user.