### PR TITLE
Update: dependencies version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,15 @@ license = "MIT OR Apache-2.0"
 exclude = [".assets/*", ".github/*"]
 
 [dependencies]
-opentelemetry = "0.11"
-opentelemetry-semantic-conventions = "0.3"
+opentelemetry = "0.12"
+opentelemetry-semantic-conventions = "0.4"
 tide = "0.15"
 url = "2.2"
-http-types = "2.9"
+http-types = "2.10"
 kv-log-macro = "1.0"
 
 [dev-dependencies]
-async-std = { version = "1.8", features = ["attributes"] }
-opentelemetry = { version = "0.11", features = ["async-std"] }
-opentelemetry-jaeger = { version = "0.10", features = ["async-std"] }
+async-std = { version = "1.9", features = ["attributes"] }
+opentelemetry = { version = "0.12", features = ["async-std"] }
+opentelemetry-jaeger = { version = "0.11", features = ["async-std"] }
 surf = "2.1"


### PR DESCRIPTION
update 
opentelemetry 0.12
opentelemetry-semantic-conventions 0.4
http-types 2.10
async-std 1.9
opentelemetry-jaeger 0.11