### PR TITLE
Update OpenTelemetry to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opentelemetry-tide"
-version = "0.6.2"
+version = "0.7.0"
 authors = [
   "Christoph Grabo <asaaki@mannaz.cc>",
   "The opentelemetry-tide Contributors"
@@ -22,8 +22,8 @@ license = "MIT OR Apache-2.0"
 exclude = [".assets/*", ".github/*"]
 
 [dependencies]
-opentelemetry = "0.12"
-opentelemetry-semantic-conventions = "0.4"
+opentelemetry = "0.13"
+opentelemetry-semantic-conventions = "0.5"
 tide = "0.16"
 url = "2.2"
 http-types = "2.10"
@@ -31,6 +31,6 @@ kv-log-macro = "1.0"
 
 [dev-dependencies]
 async-std = { version = "1.9", features = ["attributes"] }
-opentelemetry = { version = "0.12", features = ["async-std"] }
-opentelemetry-jaeger = { version = "0.11", features = ["async-std"] }
+opentelemetry = { version = "0.13", features = ["rt-async-std"] }
+opentelemetry-jaeger = { version = "0.12", features = ["async-std"] }
 surf = "2.1"

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ firefox http://localhost:16686/
 ```toml
 [dependencies]
 async-std = {version =  "1.9", features = ["attributes"]}
-opentelemetry = { version = "0.12", features = ["async-std"] }
-opentelemetry-jaeger = { version = "0.11", features = ["async-std"] }
-opentelemetry-tide = "0.6"
-tide = "0.15"
+opentelemetry = { version = "0.13", features = ["rt-async-std"] }
+opentelemetry-jaeger = { version = "0.12", features = ["async-std"] }
+opentelemetry-tide = "0.7"
+tide = "0.16"
 ```
 
 #### `server.rs`
@@ -89,10 +89,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let tags = [resource::SERVICE_VERSION.string(VERSION)];
 
-    let (tracer, _uninstall) = opentelemetry_jaeger::new_pipeline()
+    let tracer = opentelemetry_jaeger::new_pipeline()
         .with_service_name("example-server")
         .with_tags(tags.iter().map(ToOwned::to_owned))
-        .install()
+        .install_batch(opentelemetry::runtime::AsyncStd)
         .expect("pipeline install failure");
 
     let mut app = tide::new();

--- a/examples/front-server.rs
+++ b/examples/front-server.rs
@@ -42,14 +42,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         KeyValue::new("process.executable.profile", PROFILE),
     ];
 
-    let (tracer, uninstall) = opentelemetry_jaeger::new_pipeline()
+    let tracer = opentelemetry_jaeger::new_pipeline()
         .with_service_name(SVC_NAME)
         .with_tags(tags.iter().map(ToOwned::to_owned))
-        .install()
+        .install_batch(opentelemetry::runtime::AsyncStd)
         .expect("pipeline install failure");
 
     let mut app = tide::with_state(surf::client());
-    app.with(OpenTelemetryTracingMiddleware::new(tracer, uninstall));
+    app.with(OpenTelemetryTracingMiddleware::new(tracer));
 
     app.at("/").get(|req: Request<surf::Client>| async move {
         // collect current tracing data, so we can pass it down

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -30,14 +30,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         resource::PROCESS_PID.string(std::process::id().to_string()),
     ];
 
-    let (tracer, uninstall) = opentelemetry_jaeger::new_pipeline()
+    let tracer = opentelemetry_jaeger::new_pipeline()
         .with_service_name(SVC_NAME)
         .with_tags(tags.iter().map(ToOwned::to_owned))
-        .install()
+        .install_batch(opentelemetry::runtime::AsyncStd)
         .expect("pipeline install failure");
 
     let mut app = tide::new();
-    app.with(OpenTelemetryTracingMiddleware::new(tracer, uninstall));
+    app.with(OpenTelemetryTracingMiddleware::new(tracer));
     app.at("/").get(|_| async move { Ok("Hello, OpenTelemetry!") });
     app.listen("127.0.0.1:3000").await?;
 


### PR DESCRIPTION
- Version of crate bumped to 0.7 due to breaking change in interface
- Update opentelemetry, opentelemetry-semantic-conventions, and
    opentelemetry-jaeger crates to latest versions
- Removed `uninstall` from `OpenTelemetryTracingMiddleware`.
- Updated both inline and crate level documentation.
- Updated examples and tested to make sure they ran.