### PR TITLE
Disable default features for opentelemetry, tide, and http-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,13 +41,13 @@ trace = ["opentelemetry/trace"]
 metrics = ["opentelemetry/metrics", "opentelemetry-prometheus", "prometheus"]
 
 [dependencies]
-opentelemetry = "0.17"
+opentelemetry = { version = "0.17", default-features = false }
 opentelemetry-prometheus = { version = "0.10", optional = true }
 opentelemetry-semantic-conventions = "0.9"
 prometheus = { version = "0.13", optional = true }
-tide = "0.16"
+tide = { version = "0.16", default-features = false }
 url = "2.2"
-http-types = "2.12"
+http-types = { version = "2.12", default-features = false }
 kv-log-macro = "1.0"
 
 [dev-dependencies]
@@ -55,3 +55,4 @@ async-std = { version = "1.10", features = ["attributes"] }
 opentelemetry = { version = "0.17", features = ["rt-async-std"] }
 opentelemetry-jaeger = { version = "0.16", features = ["rt-async-std"] }
 surf = "2.3"
+tide = "0.16"


### PR DESCRIPTION
Leaving the default features enabled gives no way for downstream crates
to disable them.

Also adds tide with default features enabled to dev-dependencies for the
examples.