### PR TITLE
Fix the incorrect usage of `net.peer.ip` and `http.client_ip`

### DIFF
--- a/src/middlewares/tracing.rs
+++ b/src/middlewares/tracing.rs
@@ -100,8 +100,8 @@ impl<State: Clone + Send + Sync + 'static> Middleware<State> for OpenTelemetryTr
             attributes.push(trace::NET_PEER_PORT.string(sockaddr.port().to_string()));
         }
 
-        if let Some(addr) = req.peer_addr().and_then(socket_str_to_ip) {
-            attributes.push(trace::HTTP_CLIENT_IP.string(addr.to_string()));
+        if let Some(ipaddr) = req.remote().and_then(|ipaddr| IpAddr::from_str(ipaddr).ok()) {
+            attributes.push(trace::HTTP_CLIENT_IP.string(ipaddr.to_string()));
         }
 
         let span_builder = self
@@ -174,11 +174,6 @@ fn http_target(url: &Url) -> String {
         target.push_str(f);
     }
     target
-}
-
-#[inline]
-fn socket_str_to_ip(socket: &str) -> Option<IpAddr> {
-    SocketAddr::from_str(socket).ok().map(|s| s.ip())
 }
 
 #[inline]

--- a/src/middlewares/tracing.rs
+++ b/src/middlewares/tracing.rs
@@ -95,8 +95,9 @@ impl<State: Clone + Send + Sync + 'static> Middleware<State> for OpenTelemetryTr
             attributes.push(trace::NET_HOST_PORT.i64(port.into()));
         }
 
-        if let Some(addr) = req.remote().and_then(socket_str_to_ip) {
-            attributes.push(trace::NET_PEER_IP.string(addr.to_string()));
+        if let Some(sockaddr) = req.peer_addr().and_then(|sockaddr| SocketAddr::from_str(sockaddr).ok()) {
+            attributes.push(trace::NET_PEER_IP.string(sockaddr.ip().to_string()));
+            attributes.push(trace::NET_PEER_PORT.string(sockaddr.port().to_string()));
         }
 
         if let Some(addr) = req.peer_addr().and_then(socket_str_to_ip) {


### PR DESCRIPTION
Previously the usage of `net.peer.ip` and `http.client_ip` were reversed.  We tried to set `net.peer.ip` to the actual end-user's IP and tried to always set `http.client_ip` to the TCP peer's IP.

There was however also a bug where we tried to use `SocketAddr::from_str` to parse a string containing only the IP returned by `Request::remote`.